### PR TITLE
fix illegal characters in podName

### DIFF
--- a/nsenter-node.sh
+++ b/nsenter-node.sh
@@ -2,9 +2,15 @@
 set -x
 
 node=${1}
-nodeName=$(kubectl get node ${node} -o template --template='{{index .metadata.labels "kubernetes.io/hostname"}}') 
+nodeName=$(kubectl get node ${node} -o template --template='{{index .metadata.labels "kubernetes.io/hostname"}}')
 nodeSelector='"nodeSelector": { "kubernetes.io/hostname": "'${nodeName:?}'" },'
 podName=${USER}-nsenter-${node}
+# convert @ to -
+podName=${podName//@/-}
+# convert . to -
+podName=${podName//./-}
+# truncate podName to 63 characters which is the kubernetes max length for it
+podName=${podName:0:63}
 
 kubectl run ${podName:?} --restart=Never -it --rm --image overriden --overrides '
 {


### PR DESCRIPTION
I have a local username that contains my email address. This created a podName that contains both illegal characters and is longer than what kubernetes allows. Replace illegal characters and truncate the podName.