### PR TITLE
Explicitly use bash to fix "bad substitution" error

### DIFF
--- a/nsenter-node.sh
+++ b/nsenter-node.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -x
 
 node=${1}


### PR DESCRIPTION
When I run the `nsenter-node.sh` script without this change, I get the following error:
```
/home/agr/.bin/nsenter-node.sh: 9: Bad substitution
```
I think that's because `/bin/sh` is not bash on my system. So let's explicitly declare in the shebang that we use bash. Also use the recommended `/usr/bin/env` to find the path to bash.