### PR TITLE
The podName substitutions require a bash shell

### DIFF
--- a/nsenter-node.sh
+++ b/nsenter-node.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -x
 
 node=${1}


### PR DESCRIPTION
The podName sustitutions introduced in the commit https://github.com/alexei-led/nsenter/commit/fb04550faf755b33e6b8a74cc37a92e02fa1a70f require a bash shell, so I fixed the shebang line.