### PR TITLE
Modernize Dockerfile, CI, and scripts; add integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: DockerHub
+name: Build and Push
 
 on:
   push:
@@ -7,46 +7,49 @@ on:
     tags:
       - '*'
 
-jobs:
+permissions:
+  contents: read
+  packages: write
 
+jobs:
   build:
- 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
- 
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Get util-linux version
       id: get_util_linux
       run: |
         version=$(curl --silent https://api.github.com/repos/util-linux/util-linux/tags | jq -r '.[0].name' | sed -e 's/^v//')
-        echo "::debug::get util-linux version ${version}"
-        echo "::set-output name=version::${version}"
+        echo "util-linux version: ${version}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      
-    - name: Set up Docker buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-    
+
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
+        context: .
         build-args: UTIL_LINUX_VER=${{ steps.get_util_linux.outputs.version }}
         platforms: linux/amd64,linux/arm64
         tags: |
@@ -55,8 +58,21 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/nsenter:${{ steps.get_util_linux.outputs.version }}
           ghcr.io/${{ github.repository_owner }}/nsenter:latest
         push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Image digest
-      run: echo ${{ steps.docker_build.outputs.digest }}
+      run: echo "${{ steps.docker_build.outputs.digest }}"
 
- 
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run integration tests
+      run: |
+        chmod +x tests/test-docker.sh
+        ./tests/test-docker.sh

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,36 +1,48 @@
-name: Tag on Util-Linux Release
+name: Auto-update on util-linux Release
 
 on:
   schedule:
-    - cron: "0 0 * * *"
-    #- cron: "*/5 * * * *" uncomment for debug (every 5 min)
+    - cron: "0 0 * * 1"  # Weekly on Monday
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: write
 
 jobs:
   check_release:
-
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
     - name: Get latest repository tag
       id: get_latest_tag
       run: |
-        tag=$(curl --silent https://api.github.com/repos/${GITHUB_REPOSITORY}/git/refs/tags | jq -r '.[-1].ref' | awk -F/ '{print $NF}')
-        echo "::debug::git repository tag ${tag}"
-        echo "::set-output name=tag::${tag}"
-      
-    - name: Get util-linux version
+        tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+        echo "Current tag: ${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+    - name: Get latest util-linux version
       id: get_util_linux
       run: |
-        version=$(curl --silent https://api.github.com/repos/util-linux/util-linux/tags | jq -r '.[0].name' | sed -e 's/^v//')
-        echo "::debug::get util-linux version ${version}"
-        echo "::set-output name=version::${version}"
+        version=$(curl --silent --fail https://api.github.com/repos/util-linux/util-linux/tags | jq -r '.[0].name' | sed -e 's/^v//')
+        if [ -z "$version" ] || [ "$version" = "null" ]; then
+          echo "Error: could not fetch util-linux version" >&2
+          exit 1
+        fi
+        echo "util-linux version: ${version}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    - name: Tag repository with latest util-linux version, if needed
-      id: tag_repository
+    - name: Create tag if new version available
       if: steps.get_latest_tag.outputs.tag != steps.get_util_linux.outputs.version
-      uses: tvdias/github-tagger@v0.0.1
-      with:
-        repo-token: ${{ secrets.CR_PAT }}
-        tag: ${{steps.get_util_linux.outputs.version}}
-
-        
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        version="${{ steps.get_util_linux.outputs.version }}"
+        echo "New version detected: ${version}"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a "${version}" -m "util-linux ${version}"
+        git push origin "${version}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,32 @@
-FROM debian:buster as builder
+# Stage 1: Build static nsenter from util-linux sources
+FROM debian:bookworm-slim AS builder
 
-# intall gcc and supporting packages
-RUN apt-get update && apt-get install -yq make gcc gettext autopoint bison libtool automake pkg-config
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+        make gcc gettext autopoint bison libtool automake pkg-config ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
-# download util-linux sources
+# Download util-linux sources
 ARG UTIL_LINUX_VER
 ADD https://github.com/util-linux/util-linux/archive/v${UTIL_LINUX_VER}.tar.gz .
 RUN tar -xf v${UTIL_LINUX_VER}.tar.gz && mv util-linux-${UTIL_LINUX_VER} util-linux
 
-# make static version
+# Build static nsenter binary — only enable nsenter, skip everything else
 WORKDIR /code/util-linux
-RUN ./autogen.sh && ./configure
-RUN make LDFLAGS="--static" nsenter
+RUN ./autogen.sh && \
+    ./configure --disable-all-programs --enable-nsenter --without-python --without-ncurses && \
+    make LDFLAGS="--static" nsenter && \
+    strip nsenter
 
-# Final image
+# Verify the binary works and print version
+RUN ./nsenter --version
+
+# Final image: scratch with only the static binary
 FROM scratch
 
-COPY --from=builder /code/util-linux/nsenter /
+COPY --from=builder /code/util-linux/nsenter /nsenter
 
 ENTRYPOINT ["/nsenter"]

--- a/nsenter-node.sh
+++ b/nsenter-node.sh
@@ -1,44 +1,69 @@
 #!/bin/sh
-set -x
+set -eu
 
-node=${1}
-nodeName=$(kubectl get node ${node} -o template --template='{{index .metadata.labels "kubernetes.io/hostname"}}')
-nodeSelector='"nodeSelector": { "kubernetes.io/hostname": "'${nodeName:?}'" },'
-podName=${USER}-nsenter-${node}
-# convert @ to -
-podName=${podName//@/-}
-# convert . to -
-podName=${podName//./-}
-# truncate podName to 63 characters which is the kubernetes max length for it
-podName=${podName:0:63}
+# nsenter-node.sh — Enter a Kubernetes node's namespaces via a privileged pod.
+# Usage: nsenter-node.sh <node-name> [kubectl-run-flags...]
 
-kubectl run ${podName:?} --restart=Never -it --rm --image overriden --overrides '
+usage() {
+    echo "Usage: $(basename "$0") <node-name> [-- extra-kubectl-run-flags...]" >&2
+    echo "" >&2
+    echo "Enter a Kubernetes node by creating a temporary privileged pod" >&2
+    echo "that uses nsenter to access all host namespaces." >&2
+    exit 1
+}
+
+if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+fi
+
+node="$1"
+shift
+
+# Resolve the node's hostname label (validates node exists)
+nodeName=$(kubectl get node "$node" -o jsonpath='{.metadata.labels.kubernetes\.io/hostname}') || {
+    echo "Error: node '$node' not found" >&2
+    exit 1
+}
+
+if [ -z "$nodeName" ]; then
+    echo "Error: could not resolve hostname for node '$node'" >&2
+    exit 1
+fi
+
+# Build a safe pod name: lowercase, replace unsafe chars, truncate to 63 chars
+currentUser="${USER:-nsenter}"
+podName="${currentUser}-nsenter-${node}"
+podName=$(echo "$podName" | tr '[:upper:]@.' '[:lower:]--' | sed 's/[^a-z0-9-]/-/g' | cut -c1-63 | sed 's/-$//')
+
+echo "Creating pod '${podName}' on node '${nodeName}'..." >&2
+
+kubectl run "${podName}" --restart=Never -it --rm --image=overridden --overrides="
 {
-  "spec": {
-    "hostPID": true,
-    "hostNetwork": true,
-    '"${nodeSelector?}"'
-    "tolerations": [{
-        "operator": "Exists"
+  \"spec\": {
+    \"hostPID\": true,
+    \"hostNetwork\": true,
+    \"nodeSelector\": {
+      \"kubernetes.io/hostname\": \"${nodeName}\"
+    },
+    \"tolerations\": [{
+      \"operator\": \"Exists\"
     }],
-    "containers": [
+    \"containers\": [
       {
-        "name": "nsenter",
-        "image": "alexeiled/nsenter",
-        "command": [
-          "/nsenter", "--all", "--target=1", "--", "su", "-"
-        ],
-        "stdin": true,
-        "tty": true,
-        "securityContext": {
-          "privileged": true
+        \"name\": \"nsenter\",
+        \"image\": \"alexeiled/nsenter\",
+        \"command\": [\"/nsenter\", \"--all\", \"--target=1\", \"--\", \"su\", \"-\"],
+        \"stdin\": true,
+        \"tty\": true,
+        \"securityContext\": {
+          \"privileged\": true
         },
-        "resources": {
-          "requests": {
-            "cpu": "10m"
+        \"resources\": {
+          \"requests\": {
+            \"cpu\": \"10m\"
           }
         }
       }
     ]
   }
-}' --attach "$@"
+}" --attach "$@"

--- a/tests/test-docker.sh
+++ b/tests/test-docker.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Integration tests for alexeiled/nsenter Docker image.
+# Runs in CI or locally — requires Docker.
+set -eu
+
+IMAGE="${TEST_IMAGE:-alexeiled/nsenter:latest}"
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "  ✅ $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "  ❌ $1: $2"; }
+
+echo "=== nsenter Docker integration tests ==="
+echo "Image: ${IMAGE}"
+echo ""
+
+# -------------------------------------------------------------------
+# Test 1: Image exists and can be pulled/loaded
+# -------------------------------------------------------------------
+echo "▶ Test: image is available"
+if docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null 2>&1; then
+    pass "image available"
+else
+    fail "image available" "could not find or pull ${IMAGE}"
+fi
+
+# -------------------------------------------------------------------
+# Test 2: nsenter binary runs and prints version
+# -------------------------------------------------------------------
+echo "▶ Test: nsenter --version"
+version_output=$(docker run --rm "$IMAGE" --version 2>&1) || true
+if echo "$version_output" | grep -q "nsenter.*util-linux"; then
+    pass "nsenter --version → ${version_output}"
+else
+    fail "nsenter --version" "unexpected output: ${version_output}"
+fi
+
+# -------------------------------------------------------------------
+# Test 3: nsenter --help exits 0 and shows usage
+# -------------------------------------------------------------------
+echo "▶ Test: nsenter --help"
+help_output=$(docker run --rm "$IMAGE" --help 2>&1) || true
+if echo "$help_output" | grep -qi "usage"; then
+    pass "nsenter --help shows usage"
+else
+    fail "nsenter --help" "no usage text in output"
+fi
+
+# -------------------------------------------------------------------
+# Test 4: Image is minimal (< 1MB)
+# -------------------------------------------------------------------
+echo "▶ Test: image size"
+size_bytes=$(docker image inspect "$IMAGE" --format='{{.Size}}')
+size_kb=$((size_bytes / 1024))
+if [ "$size_bytes" -lt 1048576 ]; then
+    pass "image size ${size_kb}KB (< 1MB)"
+else
+    size_mb=$((size_bytes / 1048576))
+    fail "image size" "${size_mb}MB exceeds 1MB limit"
+fi
+
+# -------------------------------------------------------------------
+# Test 5: Only /nsenter exists in the image (scratch-based)
+# -------------------------------------------------------------------
+echo "▶ Test: image contains only nsenter binary"
+# Export image filesystem and check contents
+file_count=$(docker create --name nsenter-test-$$ "$IMAGE" /nsenter --version 2>/dev/null && \
+    docker export nsenter-test-$$ 2>/dev/null | tar -t 2>/dev/null | grep -cv '^\.$\|^/$' || echo "0")
+docker rm -f nsenter-test-$$ >/dev/null 2>&1 || true
+if [ "$file_count" -le 2 ]; then
+    pass "minimal image (${file_count} files)"
+else
+    fail "minimal image" "found ${file_count} files, expected ≤2"
+fi
+
+# -------------------------------------------------------------------
+# Test 6: Can enter own PID namespace (basic functionality)
+# -------------------------------------------------------------------
+echo "▶ Test: nsenter into own PID namespace"
+pid_output=$(docker run --rm --privileged --pid=host "$IMAGE" --target=1 --pid -- echo "nsenter-works" 2>&1) || true
+if echo "$pid_output" | grep -q "nsenter-works"; then
+    pass "nsenter --target=1 --pid works"
+else
+    # This may fail in rootless Docker or restricted CI — warn instead of fail
+    echo "  ⚠️  nsenter PID namespace test skipped (requires --privileged + host PID): ${pid_output}"
+fi
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASSED} passed, ${FAILED} failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Full modernization pass on the nsenter project. All changes maintain backward compatibility — same image name, same entrypoint, same usage patterns.

## Changes

### Dockerfile
- **Base image:** `debian:buster` (EOL) → `debian:bookworm-slim` (current stable, smaller)
- **Build optimization:** `--disable-all-programs --enable-nsenter` — only builds nsenter, skip everything else
- **Binary size:** `strip nsenter` reduces binary size
- **Validation:** `RUN ./nsenter --version` — build fails fast if binary is broken
- **Cleanup:** `--no-install-recommends` + rm apt lists for smaller build layer

### CI: build.yaml
- **Runner:** `ubuntu-18.04` (EOL) → `ubuntu-latest`
- **Actions:** v1/v2 → v4/v6
- **Output syntax:** deprecated `::set-output` → `$GITHUB_OUTPUT`
- **GHCR auth:** `secrets.CR_PAT` → `secrets.GITHUB_TOKEN` (no PAT needed)
- **Build cache:** Added GHA cache for faster rebuilds
- **Test job:** Runs `tests/test-docker.sh` after successful build

### CI: cron.yaml
- **Runner:** `ubuntu-18.04` → `ubuntu-latest`
- **Schedule:** Daily → weekly (Monday) — util-linux releases are rare
- **Manual trigger:** Added `workflow_dispatch`
- **Tagging:** Replaced third-party `tvdias/github-tagger` with native git tag+push (fewer deps, no PAT)
- **Error handling:** `curl --fail`, null/empty check, proper git config

### nsenter-node.sh
- **Error handling:** `set -eu` (was `set -x` debug noise)
- **Usage help:** `-h`/`--help` flag
- **Input validation:** Checks node exists before proceeding
- **Pod naming:** Proper sanitization — lowercase, replace unsafe chars, truncate 63 chars, handle missing `$USER`
- **User feedback:** Prints pod creation info to stderr

### New: tests/test-docker.sh
Integration test suite:
1. Image availability (pull or local)
2. `nsenter --version` returns valid output
3. `nsenter --help` shows usage
4. Image size < 1MB (scratch validation)
5. Minimal filesystem (only nsenter binary)
6. PID namespace entry (graceful skip if unprivileged)

## Backward Compatibility

- Same image: `alexeiled/nsenter:latest`
- Same GHCR: `ghcr.io/alexei-led/nsenter:latest`
- Same entrypoint: `/nsenter`
- Same `nsenter-node.sh` behavior (just more robust)
- Tags still follow util-linux versions

---
*🤖 Automated by Marvin • [alexei-led](https://github.com/alexei-led)*